### PR TITLE
Ranged Auto Target, Druid Fixes, Mage Fixes, Warrior Fixes

### DIFF
--- a/Snoogens PVE - Hunter Marksmanship/rotation.cs
+++ b/Snoogens PVE - Hunter Marksmanship/rotation.cs
@@ -15,7 +15,7 @@ namespace AimsharpWow.Modules
 
         #region Lists
         //Lists
-        private List<string> m_IngameCommandsList = new List<string> { "FreezingTrap", "TarTrap", "Turtle", "Intimidation", "NoInterrupts", "WildSpirits", "ResonatingArrow", "BindingShot", "Flare", };
+        private List<string> m_IngameCommandsList = new List<string> { "FreezingTrap", "TarTrap", "Turtle", "Intimidation", "NoInterrupts", "NoCycle", "WildSpirits", "ResonatingArrow", "BindingShot", "Flare", };
         private List<string> m_DebuffsList = new List<string> {  };
         private List<string> m_BuffsList = new List<string> { "Mend Pet", "Flayer's Mark", "Double Tap", "Lock and Load", };
         private List<string> m_BloodlustBuffsList = new List<string> { "Bloodlust", "Heroism", "Time Warp", "Primal Rage", "Drums of Rage" };
@@ -431,12 +431,37 @@ namespace AimsharpWow.Modules
 
             CustomFunctions.Add("HekiliWait", "if HekiliDisplayPrimary.Recommendations[1].wait ~= nil and HekiliDisplayPrimary.Recommendations[1].wait * 1000 > 0 then return math.floor(HekiliDisplayPrimary.Recommendations[1].wait * 1000) end return 0");
 
+            CustomFunctions.Add("HekiliCycle", "if HekiliDisplayPrimary.Recommendations[1].indicator ~= nil and HekiliDisplayPrimary.Recommendations[1].indicator == 'cycle' then return 1 end return 0");
+
+            CustomFunctions.Add("HekiliEnemies", "if Hekili.State.active_enemies ~= nil and Hekili.State.active_enemies > 0 then return Hekili.State.active_enemies end return 0");
+
             CustomFunctions.Add("PhialCount", "local count = GetItemCount(177278) if count ~= nil then return count end return 0");
 
             CustomFunctions.Add("TranqBuffCheck", "local markcheck = 0; if UnitExists('mouseover') and UnitIsDead('mouseover') ~= true and UnitAffectingCombat('mouseover') and IsSpellInRange('Tranquilizing Shot','mouseover') == 1 then markcheck = markcheck +1  for y = 1, 40 do local name,_,_,debuffType  = UnitAura('mouseover', y, \"RAID\") if debuffType == '' or debuffType == 'Magic' then markcheck = markcheck + 2 end end return markcheck end return 0");
 
             CustomFunctions.Add("VolleyMouseover", "if UnitExists('mouseover') and UnitIsDead('mouseover') ~= true and UnitAffectingCombat('mouseover') and IsSpellInRange('Steady Shot','mouseover') == 1 then return 1 end; return 0");
 
+            CustomFunctions.Add("GroupTargets",
+            "local UnitTargeted = 0 " +
+            "for i = 1, 20 do local unit = 'nameplate'..i " +
+                "if UnitExists(unit) then " +
+                    "if UnitCanAttack('player', unit) then " +
+                        "if GetNumGroupMembers() < 6 then " +
+                            "for p = 1, 4 do local partymember = 'party'..p " +
+                                "if UnitIsUnit(unit..'target', partymember) then UnitTargeted = p end " +
+                            "end " +
+                        "end " +
+                        "if GetNumGroupMembers() > 5 then " +
+                            "for r = 1, 40 do local raidmember = 'raid'..r " +
+                                "if UnitIsUnit(unit..'target', raidmember) then UnitTargeted = r end " +
+                            "end " +
+                        "end " +
+                        "if UnitIsUnit(unit..'target', 'player') then UnitTargeted = 5 end " +
+                    "else UnitTargeted = 0 " +
+                    "end " +
+                "end " +
+            "end " +
+            "return UnitTargeted");
 
         }
         #endregion
@@ -597,8 +622,11 @@ namespace AimsharpWow.Modules
             int SpellID1 = Aimsharp.CustomFunction("HekiliID1");
             int CooldownsToggle = Aimsharp.CustomFunction("CooldownsToggleCheck");
             int Wait = Aimsharp.CustomFunction("HekiliWait");
+            int Enemies = Aimsharp.CustomFunction("HekiliEnemies");
+            int TargetingGroup = Aimsharp.CustomFunction("GroupTargets");
 
             bool NoInterrupts= Aimsharp.IsCustomCodeOn("NoInterrupts");
+            bool NoCycle = Aimsharp.IsCustomCodeOn("NoCycle");
 
             bool Debug = GetCheckBox("Debug:") == true;
             bool UseTrinketsCD = GetCheckBox("Use Trinkets on CD, dont wait for Hekili:") == true;
@@ -893,8 +921,17 @@ namespace AimsharpWow.Modules
             #endregion
 
             #region Auto Target
+            //Hekili Cycle
+            if (!NoCycle && Aimsharp.CustomFunction("HekiliCycle") == 1 && Enemies > 1)
+            {
+                System.Threading.Thread.Sleep(50);
+                Aimsharp.Cast("TargetEnemy");
+                System.Threading.Thread.Sleep(50);
+                return true;
+            }
+
             //Auto Target
-            if ((!Enemy || Enemy && !TargetAlive() || Enemy && !TargetInCombat) && EnemiesInMelee > 0)
+            if (!NoCycle && (!Enemy || Enemy && !TargetAlive() || Enemy && !TargetInCombat) && (EnemiesInMelee > 0 || TargetingGroup > 0))
             {
                 System.Threading.Thread.Sleep(50);
                 Aimsharp.Cast("TargetEnemy");

--- a/Snoogens PVE - Mage Fire/rotation.cs
+++ b/Snoogens PVE - Mage Fire/rotation.cs
@@ -15,11 +15,11 @@ namespace AimsharpWow.Modules
 
         #region Lists
         //Lists
-        private List<string> m_IngameCommandsList = new List<string> { "NoInterrupts", "NoDecurse", "DoorofShadows", "Polymorph", "Evocation", "RingofFrost", "Flamestrike", "Meteor", };
+        private List<string> m_IngameCommandsList = new List<string> { "NoInterrupts", "NoDecurse", "NoCycle", "DoorofShadows", "Polymorph", "Evocation", "RingofFrost", "Flamestrike", "Meteor", "ArcaneExplosion", };
         private List<string> m_DebuffsList = new List<string> { "Polymorph", };
         private List<string> m_BuffsList = new List<string> { "Arcane Intellect", "Arcane Power", "Shifting Power", };
         private List<string> m_BloodlustBuffsList = new List<string> { "Bloodlust", "Heroism", "Time Warp", "Primal Rage", "Drums of Rage" };
-        private List<string> m_ItemsList = new List<string> { "Phial of Serenity", "Healthstone", "Mana Gem", };
+        private List<string> m_ItemsList = new List<string> { "Phial of Serenity", "Healthstone", };
 
         private List<string> m_SpellBook = new List<string> {
             //Covenants
@@ -202,9 +202,6 @@ namespace AimsharpWow.Modules
             
             //Phial
             Macros.Add("PhialofSerenity", "/use Phial of Serenity");
-            
-            //Mana Gem
-            Macros.Add("ManaGem", "/use Mana Gem");
 
             //SpellQueueWindow
             Macros.Add("SetSpellQueueCvar", "/console SpellQueueWindow " + (Aimsharp.Latency + 100));
@@ -223,6 +220,7 @@ namespace AimsharpWow.Modules
             Macros.Add("RC_FOC", "/cast [@focus] Remove Curse");
 
             Macros.Add("PolymorphMO", "/cast [@mouseover] Polymorph");
+            Macros.Add("SpellstealMO", "/cast [@mouseover] Spellsteal");
             Macros.Add("RingofFrostC", "/cast [@cursor] RingofFrost");
             Macros.Add("FlamestrikeC", "/cast [@cursor] Flamestrike");
             Macros.Add("MeteorC", "/cast [@cursor] Meteor");
@@ -268,6 +266,10 @@ namespace AimsharpWow.Modules
 
             CustomFunctions.Add("HekiliWait", "if HekiliDisplayPrimary.Recommendations[1].wait ~= nil and HekiliDisplayPrimary.Recommendations[1].wait * 1000 > 0 then return math.floor(HekiliDisplayPrimary.Recommendations[1].wait * 1000) end return 0");
 
+            CustomFunctions.Add("HekiliCycle", "if HekiliDisplayPrimary.Recommendations[1].indicator ~= nil and HekiliDisplayPrimary.Recommendations[1].indicator == 'cycle' then return 1 end return 0");
+
+            CustomFunctions.Add("HekiliEnemies", "if Hekili.State.active_enemies ~= nil and Hekili.State.active_enemies > 0 then return Hekili.State.active_enemies end return 0");
+
             CustomFunctions.Add("PhialCount", "local count = GetItemCount(177278) if count ~= nil then return count end return 0");
 
             CustomFunctions.Add("FlamestrikeMouseover", "if UnitExists('mouseover') and UnitIsDead('mouseover') ~= true and UnitAffectingCombat('mouseover') and IsSpellInRange('Fireball','mouseover') == 1 then return 1 end; return 0");
@@ -293,6 +295,31 @@ namespace AimsharpWow.Modules
             "if type ~= nil and type == \"Curse\" then y = y +16; end end " +
             "return y");
 
+            CustomFunctions.Add("GroupTargets",
+            "local UnitTargeted = 0 " +
+            "for i = 1, 20 do local unit = 'nameplate'..i " +
+                "if UnitExists(unit) then " +
+                    "if UnitCanAttack('player', unit) then " +
+                        "if GetNumGroupMembers() < 6 then " +
+                            "for p = 1, 4 do local partymember = 'party'..p " +
+                                "if UnitIsUnit(unit..'target', partymember) then UnitTargeted = p end " +
+                            "end " +
+                        "end " +
+                        "if GetNumGroupMembers() > 5 then " +
+                            "for r = 1, 40 do local raidmember = 'raid'..r " +
+                                "if UnitIsUnit(unit..'target', raidmember) then UnitTargeted = r end " +
+                            "end " +
+                        "end " +
+                        "if UnitIsUnit(unit..'target', 'player') then UnitTargeted = 5 end " +
+                    "else UnitTargeted = 0 " +
+                    "end " +
+                "end " +
+            "end " +
+            "return UnitTargeted");
+
+            CustomFunctions.Add("SpellstealCheckMouseover", "local markcheck = 0; if UnitExists('mouseover') and UnitIsDead('mouseover') ~= true and UnitAffectingCombat('mouseover') and IsSpellInRange('Spellsteal','mouseover') == 1 then markcheck = markcheck +1  for y = 1, 40 do local name,_,_,debuffType,_,_,_,isStealable  = UnitAura('mouseover', y) if debuffType == 'Magic' and isStealable == true then markcheck = markcheck + 2 end end return markcheck end return 0");
+
+            CustomFunctions.Add("SpellstealCheckTarget", "local markcheck = 0; if UnitExists('target') and UnitIsDead('target') ~= true and UnitAffectingCombat('target') and IsSpellInRange('Spellsteal','target') == 1 then markcheck = markcheck +1  for y = 1, 40 do local name,_,_,debuffType,_,_,_,isStealable  = UnitAura('target', y) if debuffType == 'Magic' and isStealable == true then markcheck = markcheck + 2 end end return markcheck end return 0");
 
         }
         #endregion
@@ -312,6 +339,8 @@ namespace AimsharpWow.Modules
             Settings.Add(new Setting("General"));
             Settings.Add(new Setting("Auto Start Combat:", true));
             Settings.Add(new Setting("Arcane Intellect Out of Combat:", true));
+            Settings.Add(new Setting("Auto Spellsteal Target:", true));
+            Settings.Add(new Setting("Auto Spellsteal Mouseover:", true));
             Settings.Add(new Setting("Auto Blazing Barrier @ HP%", 0, 100, 90));
             Settings.Add(new Setting("Auto Ice Block @ HP%", 0, 100, 25));
             Settings.Add(new Setting("Auto Alter Time @ HP%", 0, 100, 15));
@@ -337,17 +366,20 @@ namespace AimsharpWow.Modules
             Aimsharp.QuickDelay = 150;
             Aimsharp.SlowDelay = 350;
 
-            Aimsharp.PrintMessage("Snoogens PVE - Mage Arcane", Color.Yellow);
+            Aimsharp.PrintMessage("Snoogens PVE - Mage Fire", Color.Yellow);
             Aimsharp.PrintMessage("This rotation requires the Hekili Addon", Color.Red);
             Aimsharp.PrintMessage("Hekili > Toggles > Unbind everything", Color.Brown);
             Aimsharp.PrintMessage("Hekili > Toggles > Bind \"Cooldowns\" & \"Display Mode\"", Color.Brown);
             Aimsharp.PrintMessage("-----", Color.Black);
             Aimsharp.PrintMessage("- General -", Color.Yellow);
             Aimsharp.PrintMessage("/xxxxx NoInterrupts - Disables Interrupts", Color.Yellow);
+            Aimsharp.PrintMessage("/xxxxx NoCycle - Disables Target Cycle", Color.Yellow);
             Aimsharp.PrintMessage("/xxxxx NoDecurse - Disables Decurse", Color.Yellow);
             Aimsharp.PrintMessage("/xxxxx Polymorph - Casts Polymorph @ Mouseover next GCD", Color.Yellow);
-            Aimsharp.PrintMessage("/xxxxx Evocation - Casts Evocation @ next GCD", Color.Yellow);
-            Aimsharp.PrintMessage("/xxxxx RingofFrost - Casts Ring of Frost @ next GCD", Color.Yellow);
+            Aimsharp.PrintMessage("/xxxxx ArcaneExplosion - Spams Arcane Explosion until turned Off", Color.Yellow);
+            Aimsharp.PrintMessage("/xxxxx RingofFrost - Casts Ring of Frost @ next GCD", Color.Yellow);      
+            Aimsharp.PrintMessage("/xxxxx Flamestrike - Casts Flamestrike @ next GCD", Color.Yellow);
+            Aimsharp.PrintMessage("/xxxxx Meteor - Casts Meteor @ next GCD", Color.Yellow);
             Aimsharp.PrintMessage("/xxxxx DoorofShadows - Casts Door of Shadows @ next GCD", Color.Yellow);
             Aimsharp.PrintMessage("-----", Color.Black);
 
@@ -453,9 +485,12 @@ namespace AimsharpWow.Modules
             int SpellID1 = Aimsharp.CustomFunction("HekiliID1");
             int CooldownsToggle = Aimsharp.CustomFunction("CooldownsToggleCheck");
             int Wait = Aimsharp.CustomFunction("HekiliWait");
+            int Enemies = Aimsharp.CustomFunction("HekiliEnemies");
+            int TargetingGroup = Aimsharp.CustomFunction("GroupTargets");
 
             bool NoInterrupts= Aimsharp.IsCustomCodeOn("NoInterrupts");
             bool NoDecurse = Aimsharp.IsCustomCodeOn("NoDecurse");
+            bool NoCycle = Aimsharp.IsCustomCodeOn("NoCycle");
 
             bool Debug = GetCheckBox("Debug:") == true;
             bool UseTrinketsCD = GetCheckBox("Use Trinkets on CD, dont wait for Hekili:") == true;
@@ -613,20 +648,6 @@ namespace AimsharpWow.Modules
                 }
             }
 
-            //Auto Healthstone
-            if (Aimsharp.CanUseItem("Healthstone", false) && Aimsharp.ItemCooldown("Healthstone") == 0)
-            {
-                if (Aimsharp.Health("player") <= GetSlider("Auto Healthstone @ HP%"))
-                {
-                    if (Debug)
-                    {
-                        Aimsharp.PrintMessage("Using Healthstone - Player HP% " + Aimsharp.Health("player") + " due to setting being on HP% " + GetSlider("Auto Healthstone @ HP%"), Color.Purple);
-                    }
-                    Aimsharp.Cast("Healthstone");
-                    return true;
-                }
-            }
-
             //Phial of Serenity
             if (Aimsharp.CanUseItem("Phial of Serenity", false) && Aimsharp.ItemCooldown("Phial of Serenity") == 0)
             {
@@ -682,6 +703,34 @@ namespace AimsharpWow.Modules
                     return true;
                 }
             }
+
+            //Auto Spellsteal Mouseover
+            if (Aimsharp.CanCast("Spellsteal", "mouseover", true, true))
+            {
+                if (GetCheckBox("Auto Spellsteal Mouseover:") && Aimsharp.CustomFunction("SpellstealCheckMouseover") == 3)
+                {
+                    Aimsharp.Cast("SpellstealMO");
+                    if (Debug)
+                    {
+                        Aimsharp.PrintMessage("Casting Spellsteal on Mouseover", Color.Purple);
+                    }
+                    return true;
+                }
+            }
+
+            //Auto Spellsteal Target
+            if (Aimsharp.CanCast("Spellsteal", "target", true, true))
+            {
+                if (GetCheckBox("Auto Spellsteal Target:") && Aimsharp.CustomFunction("SpellstealCheckTarget") == 3)
+                {
+                    Aimsharp.Cast("Spellsteal");
+                    if (Debug)
+                    {
+                        Aimsharp.PrintMessage("Casting Spellsteal on Target", Color.Purple);
+                    }
+                    return true;
+                }
+            }
             #endregion
 
             #region Queues
@@ -706,24 +755,14 @@ namespace AimsharpWow.Modules
                 return true;
             }
 
-            bool Evocation = Aimsharp.IsCustomCodeOn("Evocation");
-            if (Aimsharp.SpellCooldown("Evocation") - Aimsharp.GCD() > 2000 && Evocation)
+            bool ArcaneExplosion = Aimsharp.IsCustomCodeOn("ArcaneExplosion");
+            if (ArcaneExplosion && Aimsharp.CanCast("Arcane Explosion", "player", false, true))
             {
                 if (Debug)
                 {
-                    Aimsharp.PrintMessage("Turning Off Evocation Queue", Color.Purple);
+                    Aimsharp.PrintMessage("Casting Arcane Explosion - Queue", Color.Purple);
                 }
-                Aimsharp.Cast("EvocationOff");
-                return true;
-            }
-
-            if (Evocation && Aimsharp.CanCast("Evocation", "target", true, true) && !Moving)
-            {
-                if (Debug)
-                {
-                    Aimsharp.PrintMessage("Casting Evocation - Queue", Color.Purple);
-                }
-                Aimsharp.Cast("Evocation");
+                Aimsharp.Cast("Arcane Explosion");
                 return true;
             }
 
@@ -919,8 +958,17 @@ namespace AimsharpWow.Modules
             #endregion
 
             #region Auto Target
+            //Hekili Cycle
+            if (!NoCycle && Aimsharp.CustomFunction("HekiliCycle") == 1 && Enemies > 1)
+            {
+                System.Threading.Thread.Sleep(50);
+                Aimsharp.Cast("TargetEnemy");
+                System.Threading.Thread.Sleep(50);
+                return true;
+            }
+
             //Auto Target
-            if ((!Enemy || Enemy && !TargetAlive() || Enemy && !TargetInCombat) && EnemiesInMelee > 0)
+            if (!NoCycle && (!Enemy || Enemy && !TargetAlive() || Enemy && !TargetInCombat) && (EnemiesInMelee > 0 || TargetingGroup > 0))
             {
                 System.Threading.Thread.Sleep(50);
                 Aimsharp.Cast("TargetEnemy");
@@ -931,7 +979,7 @@ namespace AimsharpWow.Modules
 
             if (Aimsharp.TargetIsEnemy() && TargetAlive() && TargetInCombat && Wait <= 200)
             {
-                if (Aimsharp.Range("target") <= 40 && !Aimsharp.HasDebuff("Polymorph", "target", true) && !Polymorph)
+                if (Aimsharp.Range("target") <= 40 && !Aimsharp.HasDebuff("Polymorph", "target", true) && !Polymorph && !ArcaneExplosion)
                 {
                     #region Trinkets
                     if (CooldownsToggle == 1 && UseTrinketsCD && Aimsharp.CanUseTrinket(0))
@@ -1625,24 +1673,14 @@ namespace AimsharpWow.Modules
                 return true;
             }
 
-            bool Evocation = Aimsharp.IsCustomCodeOn("Evocation");
-            if (Aimsharp.SpellCooldown("Evocation") - Aimsharp.GCD() > 2000 && Evocation)
+            bool ArcaneExplosion = Aimsharp.IsCustomCodeOn("ArcaneExplosion");
+            if (ArcaneExplosion && Aimsharp.CanCast("Arcane Explosion", "player", false, true))
             {
                 if (Debug)
                 {
-                    Aimsharp.PrintMessage("Turning Off Evocation Queue", Color.Purple);
+                    Aimsharp.PrintMessage("Casting Arcane Explosion - Queue", Color.Purple);
                 }
-                Aimsharp.Cast("EvocationOff");
-                return true;
-            }
-
-            if (Evocation && Aimsharp.CanCast("Evocation", "target", true, true) && !Moving)
-            {
-                if (Debug)
-                {
-                    Aimsharp.PrintMessage("Casting Evocation - Queue", Color.Purple);
-                }
-                Aimsharp.Cast("Evocation");
+                Aimsharp.Cast("Arcane Explosion");
                 return true;
             }
 

--- a/Snoogens PVE - Warrior Fury/rotation.cs
+++ b/Snoogens PVE - Warrior Fury/rotation.cs
@@ -15,7 +15,7 @@ namespace AimsharpWow.Modules
 
         #region Lists
         //Lists
-        private List<string> m_IngameCommandsList = new List<string> { "StormBolt", "IntimidatingShout", "SpearofBastion", "DoorofShadows", "NoInterrupts", "NoCycle", };
+        private List<string> m_IngameCommandsList = new List<string> { "StormBolt", "IntimidatingShout", "SpearofBastion", "Bladestorm", "DoorofShadows", "NoInterrupts", "NoCycle", };
         private List<string> m_DebuffsList = new List<string> { };
         private List<string> m_BuffsList = new List<string> { "Defensive Stance", "Battle Shout", "Bladestorm", "Voracious Culling Blade", };
         private List<string> m_BloodlustBuffsList = new List<string> { "Bloodlust", "Heroism", "Time Warp", "Primal Rage", "Drums of Rage" };
@@ -188,6 +188,7 @@ namespace AimsharpWow.Modules
             Macros.Add("IntimidatingShoutOff", "/" + FiveLetters + " IntimidatingShout");
             Macros.Add("SpearofBastionOff", "/" + FiveLetters + " SpearofBastion");
             Macros.Add("DoorofShadowsOff", "/" + FiveLetters + " DoorofShadows");
+            Macros.Add("BladestormOff", "/" + FiveLetters + " Bladestorm");
 
             //CancelAura
             Macros.Add("CancelBladestorm", "/cancelaura Bladestorm");
@@ -288,6 +289,7 @@ namespace AimsharpWow.Modules
             Aimsharp.PrintMessage("/xxxxx NoCycle - Disables Target Cycle", Color.Yellow);
             Aimsharp.PrintMessage("/xxxxx StormBolt - Casts Storm Bolt @ Target on the next GCD", Color.Yellow);
             Aimsharp.PrintMessage("/xxxxx IntimidatingShout - Casts Intimidating Shout @ Target on the next GCD", Color.Yellow);
+            Aimsharp.PrintMessage("/xxxxx Bladestorm - Casts Bladestorm @ next GCD", Color.Yellow);
             Aimsharp.PrintMessage("/xxxxx SpearofBastion - Casts Spear of Bastion @ Manual/Player on the next GCD", Color.Yellow);
             Aimsharp.PrintMessage("/xxxxx DoorofShadows - Casts Spear of Bastion @ Manual on the next GCD", Color.Yellow);
             Aimsharp.PrintMessage("-----", Color.Black);
@@ -395,6 +397,7 @@ namespace AimsharpWow.Modules
             int Wait = Aimsharp.CustomFunction("HekiliWait");
 
             bool NoInterrupts = Aimsharp.IsCustomCodeOn("NoInterrupts");
+            bool NoCycle = Aimsharp.IsCustomCodeOn("NoCycle");
 
             bool Debug = GetCheckBox("Debug:") == true;
             bool UseTrinketsCD = GetCheckBox("Use Trinkets on CD, dont wait for Hekili:") == true;
@@ -426,6 +429,21 @@ namespace AimsharpWow.Modules
             }
             #endregion
 
+            #region Above Pause Logic
+            bool Bladestorm = Aimsharp.IsCustomCodeOn("Bladestorm");
+            if (Aimsharp.SpellCooldown("Bladestorm") - Aimsharp.GCD() > 2000 && Aimsharp.BuffRemaining("Bladestorm", "player", true) <= 0 && Bladestorm)
+            {
+                Aimsharp.Cast("BladestormOff");
+                return true;
+            }
+
+            if (SpellID1 == 999999 && Aimsharp.HasBuff("Bladestorm", "player", true) && !Bladestorm)
+            {
+                Aimsharp.Cast("CancelBladestorm");
+                return true;
+            }
+            #endregion
+
             #region Pause Checks
             if (Aimsharp.CastingID("player") > 0 || Aimsharp.IsChanneling("player"))
             {
@@ -445,14 +463,6 @@ namespace AimsharpWow.Modules
             if (Aimsharp.IsCustomCodeOn("DoorofShadows") && Aimsharp.SpellCooldown("Door of Shadows") - Aimsharp.GCD() <= 0 && Aimsharp.CustomFunction("IsRMBDown") == 1)
             {
                 return false;
-            }
-            #endregion
-
-            #region CancelLogic
-            if (SpellID1 == 999999 && Aimsharp.HasBuff("Bladestorm", "player", true))
-            {
-                Aimsharp.Cast("CancelBladestorm");
-                return true;
             }
             #endregion
 
@@ -559,6 +569,20 @@ namespace AimsharpWow.Modules
 
             #region Queues
             //Queues
+            //Queue Bladestorm
+            if (Aimsharp.SpellCooldown("Bladestorm") - Aimsharp.GCD() > 2000 && Aimsharp.BuffRemaining("Bladestorm", "player", true) <= 0 && Bladestorm)
+            {
+                Aimsharp.Cast("BladestormOff");
+                return true;
+            }
+
+            if (Bladestorm && Aimsharp.CanCast("Bladestorm", "target", true, true))
+            {
+                Aimsharp.PrintMessage("Queued Bladestorm");
+                Aimsharp.Cast("Bladestorm");
+                return true;
+            }
+
             //Queue StormBolt
             bool StormBolt = Aimsharp.IsCustomCodeOn("StormBolt");
             if (Aimsharp.SpellCooldown("Storm Bolt") - Aimsharp.GCD() > 2000 && StormBolt && Aimsharp.TargetIsEnemy() && TargetAlive() && TargetInCombat)
@@ -646,7 +670,7 @@ namespace AimsharpWow.Modules
 
             #region Auto Target
             //Hekili Cycle
-            if (Aimsharp.CustomFunction("HekiliCycle") == 1 && EnemiesInMelee > 1)
+            if (!NoCycle && Aimsharp.CustomFunction("HekiliCycle") == 1 && EnemiesInMelee > 1)
             {
                 System.Threading.Thread.Sleep(50);
                 Aimsharp.Cast("TargetEnemy");
@@ -655,7 +679,7 @@ namespace AimsharpWow.Modules
             }
 
             //Auto Target
-            if ((!Enemy || Enemy && !TargetAlive() || Enemy && !TargetInCombat) && EnemiesInMelee > 0)
+            if (!NoCycle && (!Enemy || Enemy && !TargetAlive() || Enemy && !TargetInCombat) && EnemiesInMelee > 0)
             {
                 System.Threading.Thread.Sleep(50);
                 Aimsharp.Cast("TargetEnemy");
@@ -1130,6 +1154,21 @@ namespace AimsharpWow.Modules
             }
             #endregion
 
+            #region Above Pause Logic
+            bool Bladestorm = Aimsharp.IsCustomCodeOn("Bladestorm");
+            if (Aimsharp.SpellCooldown("Bladestorm") - Aimsharp.GCD() > 2000 && Aimsharp.BuffRemaining("Bladestorm", "player", true) <= 0 && Bladestorm)
+            {
+                Aimsharp.Cast("BladestormOff");
+                return true;
+            }
+
+            if (SpellID1 == 999999 && Aimsharp.HasBuff("Bladestorm", "player", true) && !Bladestorm)
+            {
+                Aimsharp.Cast("CancelBladestorm");
+                return true;
+            }
+            #endregion
+
             #region Pause Checks
             if (Aimsharp.CastingID("player") > 0 || Aimsharp.IsChanneling("player"))
             {
@@ -1154,6 +1193,20 @@ namespace AimsharpWow.Modules
 
             #region Queues
             //Queues
+            //Queue Bladestorm
+            if (Aimsharp.SpellCooldown("Bladestorm") - Aimsharp.GCD() > 2000 && Aimsharp.BuffRemaining("Bladestorm", "player", true) <= 0 && Bladestorm)
+            {
+                Aimsharp.Cast("BladestormOff");
+                return true;
+            }
+
+            if (Bladestorm && Aimsharp.CanCast("Bladestorm", "target", true, true))
+            {
+                Aimsharp.PrintMessage("Queued Bladestorm");
+                Aimsharp.Cast("Bladestorm");
+                return true;
+            }
+
             //Queue StormBolt
             bool StormBolt = Aimsharp.IsCustomCodeOn("StormBolt");
             if (Aimsharp.SpellCooldown("Storm Bolt") - Aimsharp.GCD() > 2000 && StormBolt && Aimsharp.TargetIsEnemy() && TargetAlive() && TargetInCombat)


### PR DESCRIPTION
Ranged Auto Target for all Ranged rotations - reliable and safe auto targeting while in an Instance.

Druid Feral - Soothe Fix. !NoCycle fix.

Mage Fire/Arcane - Spellsteal Fix. ArcaneExplosion Spam Queue. Ring of Frost Queue fix. Evocation Queue fix.

Warrior Fury/Arms - Bladestorm Queue. !NoCycle fix. StormBolt Queue fix. IntimidationShout Queue fix.